### PR TITLE
[QoL] Restore default boxset if advanced search opened with none stored

### DIFF
--- a/src/components/advanced-search/AdvancedSearch.svelte
+++ b/src/components/advanced-search/AdvancedSearch.svelte
@@ -2,16 +2,13 @@
 	import BoxSet from './BoxSet.svelte';
 	import Button from './Button.svelte';
 	import { boxSetsStore, getNewBoxSet } from '$stores';
-  import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 
-  const dispatch = createEventDispatcher();
-	
+	const dispatch = createEventDispatcher();
+
 	const onClose = (index: number) => () => {
-		$boxSetsStore = [
-			...$boxSetsStore.slice(0, index),
-			...$boxSetsStore.slice(index + 1),
-		];
-	}
+		$boxSetsStore = [...$boxSetsStore.slice(0, index), ...$boxSetsStore.slice(index + 1)];
+	};
 
 	// instead of bubbling up an event, we're going to create a central event listener.
 	// this will capture all child events
@@ -20,29 +17,29 @@
 
 		const el = e.target as HTMLElement;
 		if (el.tagName !== 'INPUT') return;
-  
+
 		// it is possible for this to ACTUALLY trigger a submit event and we need to cancel that.
 		e.preventDefault();
 		dispatch('search');
 	}
+
+	onMount(() => {
+		// If the user has previously deleted all boxSets, restore the default upon mounting again.
+		if ($boxSetsStore.length === 0) {
+			$boxSetsStore = [getNewBoxSet()];
+		}
+	});
 </script>
 
 <form on:keydown={handlePossibleFormSubmit} on:submit|preventDefault>
 	{#each $boxSetsStore as { type, boxes }, i}
-		<BoxSet 
-			bind:type
-			bind:boxes 
-			on:close={onClose(i)} />
+		<BoxSet bind:type bind:boxes on:close={onClose(i)} />
 	{/each}
 </form>
 
 <div class="buttons">
-	<Button on:click={() => $boxSetsStore = [...$boxSetsStore, getNewBoxSet()]}>
-		Add Rule
-	</Button>	
-	<Button on:click={() => dispatch('search')} hue={200}>
-		Search
-	</Button>	
+	<Button on:click={() => ($boxSetsStore = [...$boxSetsStore, getNewBoxSet()])}>Add Rule</Button>
+	<Button on:click={() => dispatch('search')} hue={200}>Search</Button>
 </div>
 
 <style>


### PR DESCRIPTION
Hey there! Just a little quality of life change. When the user enters the advanced search mode, removes the default filter, and goes back to simple search, the next time they go to advanced search mode there will be no filters here which could leave novice users confused. Doesn't make much practical difference but removes a confusion I have sometimes when opening up the tool again after awhile.

Before:
https://user-images.githubusercontent.com/7156389/192647448-f40e80f4-836e-4a1b-b935-cc65dbdfe40f.mov


After:
https://user-images.githubusercontent.com/7156389/192647104-33ce19c4-e16c-4864-9e2a-04edf5deac1b.mov

ps. my linter disagreed with urs get rekt