### PR TITLE
Add command palette with Cmd+K shortcut

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onMounted } from "vue";
 import { hasFirstLoaded, selectedCodepoint, searchMode, results } from "$stores";
+import { useTheme, useGlobalKeyboard } from "$src/composables";
 
 import GitHubIcon from "$icons/GitHubIcon.vue";
 import ResultsContainer from "$components/table-container/ResultsContainer.vue";
@@ -9,6 +10,11 @@ import Header from "$components/Header.vue";
 import AdvancedSearch from "$components/advanced-search/AdvancedSearch.vue";
 import Loader from "$components/Loader.vue";
 import InfoContainer from "$components/table-container/InfoContainer.vue";
+import CommandPalette from "$components/CommandPalette.vue";
+
+// Initialize theme and global keyboard shortcuts
+useTheme();
+useGlobalKeyboard();
 
 onMounted(() => {
   import("./queryProxy");
@@ -50,6 +56,7 @@ onMounted(() => {
     </div>
     <aside v-if="selectedCodepoint" />
   </div>
+  <CommandPalette />
 </template>
 
 <style>

--- a/src/components/CommandPalette.vue
+++ b/src/components/CommandPalette.vue
@@ -1,0 +1,224 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, onUnmounted, nextTick } from "vue";
+import { Modal } from "$lib/components/overlay";
+import {
+  isCommandPaletteOpen,
+  searchQuery,
+  selectedIndex,
+  filteredCommands,
+  closeCommandPalette,
+  executeCommand,
+  registerCommand,
+  unregisterCommand,
+  type Command,
+} from "$stores/commandPalette";
+import { searchMode } from "$stores";
+import { useTheme } from "$src/composables/useTheme";
+
+const { toggleTheme, isDarkTheme } = useTheme();
+
+const inputRef = ref<HTMLInputElement | null>(null);
+const listRef = ref<HTMLDivElement | null>(null);
+
+// Register default commands
+onMounted(() => {
+  registerCommand({
+    id: "toggle-theme",
+    name: "Toggle Theme",
+    description: "Switch between light and dark mode",
+    shortcut: "",
+    category: "Appearance",
+    action: toggleTheme,
+  });
+
+  registerCommand({
+    id: "toggle-search-mode",
+    name: "Toggle Search Mode",
+    description: "Switch between simple and advanced search",
+    category: "Search",
+    action: () => {
+      searchMode.value = searchMode.value === "advanced" ? "simple" : "advanced";
+    },
+  });
+});
+
+onUnmounted(() => {
+  unregisterCommand("toggle-theme");
+  unregisterCommand("toggle-search-mode");
+});
+
+// Focus input when modal opens
+watch(isCommandPaletteOpen, (open) => {
+  if (open) {
+    nextTick(() => {
+      inputRef.value?.focus();
+    });
+  }
+});
+
+// Reset selected index when filtered results change
+watch(filteredCommands, () => {
+  selectedIndex.value = 0;
+});
+
+// Scroll selected item into view
+watch(selectedIndex, (index) => {
+  nextTick(() => {
+    const list = listRef.value;
+    if (!list) return;
+    const items = list.querySelectorAll(".command-item");
+    const item = items[index] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: "nearest" });
+  });
+});
+
+const handleKeydown = (e: KeyboardEvent) => {
+  const commands = filteredCommands.value;
+
+  switch (e.key) {
+    case "ArrowDown":
+      e.preventDefault();
+      selectedIndex.value = (selectedIndex.value + 1) % commands.length;
+      break;
+    case "ArrowUp":
+      e.preventDefault();
+      selectedIndex.value = (selectedIndex.value - 1 + commands.length) % commands.length;
+      break;
+    case "Enter":
+      e.preventDefault();
+      if (commands[selectedIndex.value]) {
+        executeCommand(commands[selectedIndex.value]);
+      }
+      break;
+  }
+};
+
+const handleItemClick = (cmd: Command) => {
+  executeCommand(cmd);
+};
+
+const handleItemHover = (index: number) => {
+  selectedIndex.value = index;
+};
+</script>
+
+<template>
+  <Modal :open="isCommandPaletteOpen" @close="closeCommandPalette">
+    <div class="command-palette">
+      <div class="search-container">
+        <input
+          ref="inputRef"
+          v-model="searchQuery"
+          type="text"
+          placeholder="Type a command..."
+          class="search-input"
+          @keydown="handleKeydown"
+        />
+      </div>
+
+      <div ref="listRef" class="command-list">
+        <template v-if="filteredCommands.length">
+          <button
+            v-for="(cmd, index) in filteredCommands"
+            :key="cmd.id"
+            :class="['command-item', index === selectedIndex && 'selected']"
+            @click="handleItemClick(cmd)"
+            @mouseenter="handleItemHover(index)"
+          >
+            <div class="command-info">
+              <span class="command-name">{{ cmd.name }}</span>
+              <span v-if="cmd.description" class="command-description">{{ cmd.description }}</span>
+            </div>
+            <span v-if="cmd.shortcut" class="command-shortcut">{{ cmd.shortcut }}</span>
+          </button>
+        </template>
+        <div v-else class="no-results">No commands found</div>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<style scoped>
+.command-palette {
+  width: 500px;
+  max-width: 90vw;
+}
+
+.search-container {
+  padding: var(--space-3);
+  border-bottom: var(--border-width-1) solid var(--color-border);
+}
+
+.search-input {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: none;
+  background: var(--color-bg-offset);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  color: var(--color-text);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.search-input::placeholder {
+  color: var(--color-text-tertiary);
+}
+
+.command-list {
+  max-height: 400px;
+  overflow-y: auto;
+  padding: var(--space-2);
+}
+
+.command-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-align: left;
+  color: var(--color-text);
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.command-item:hover,
+.command-item.selected {
+  background: var(--color-bg);
+}
+
+.command-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.command-name {
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.command-description {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+}
+
+.command-shortcut {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  background: var(--color-bg);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family-mono);
+}
+
+.no-results {
+  padding: var(--space-4);
+  text-align: center;
+  color: var(--color-text-tertiary);
+}
+</style>

--- a/src/components/EasySearch.vue
+++ b/src/components/EasySearch.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from "vue";
-import { easySearch } from "$stores";
+import { easySearch, isCommandPaletteOpen } from "$stores";
 import { debounce } from "$utils/debounce";
 
 interface Props {
@@ -38,6 +38,8 @@ function trySearch() {
 }
 
 function handleKeyDown(e: KeyboardEvent) {
+  if (isCommandPaletteOpen.value) return;
+
   const inputIsFocused = document.activeElement === inputEl.value;
   if (inputIsFocused) return;
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { searchMode } from "$stores";
 import FilterIcon from "$icons/FilterIcon.vue";
-import ThemeSwitcher from "./ThemeSwitcher.vue";
 
 function toggleSearchMode() {
   searchMode.value = searchMode.value === "advanced" ? "simple" : "advanced";
@@ -17,7 +16,6 @@ function toggleSearchMode() {
     </div>
 
     <div class="buttons">
-      <ThemeSwitcher />
       <button :class="['styled', searchMode === 'advanced' && 'active']" @click="toggleSearchMode">
         <FilterIcon :active="searchMode === 'advanced'" />
       </button>

--- a/src/components/table-container/info-tables/Properties.vue
+++ b/src/components/table-container/info-tables/Properties.vue
@@ -28,6 +28,7 @@ h3 {
   flex-wrap: wrap;
   gap: 5px;
   text-align: left;
+  margin-bottom: var(--space-8);
 }
 .properties span {
   background: var(--bg-offset);

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,0 +1,2 @@
+export { useTheme } from "./useTheme";
+export { useGlobalKeyboard } from "./useGlobalKeyboard";

--- a/src/composables/useGlobalKeyboard.ts
+++ b/src/composables/useGlobalKeyboard.ts
@@ -1,0 +1,22 @@
+import { onMounted, onUnmounted } from "vue";
+import { openCommandPalette, isCommandPaletteOpen } from "$stores/commandPalette";
+
+export function useGlobalKeyboard() {
+  const handleKeydown = (e: KeyboardEvent) => {
+    // Cmd+K (Mac) or Ctrl+K (Windows/Linux)
+    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      e.preventDefault();
+      if (!isCommandPaletteOpen.value) {
+        openCommandPalette();
+      }
+    }
+  };
+
+  onMounted(() => {
+    window.addEventListener("keydown", handleKeydown);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener("keydown", handleKeydown);
+  });
+}

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -1,0 +1,60 @@
+import { ref, onMounted, onUnmounted } from "vue";
+
+const isDarkTheme = ref(false);
+
+let initialized = false;
+let colorSchemeMedia: MediaQueryList | null = null;
+
+const updateTheme = (darkTheme: boolean) => {
+  const newTheme = darkTheme ? "dark" : "light";
+  document.documentElement.dataset.theme = newTheme;
+  localStorage.setItem("color-scheme", newTheme);
+};
+
+const getColorSchemeLS = () => localStorage.getItem("color-scheme") as "dark" | "light" | null;
+
+const onColorSchemeChange = (e: MediaQueryListEvent) => {
+  if (getColorSchemeLS()) return;
+  isDarkTheme.value = e.matches;
+  updateTheme(isDarkTheme.value);
+};
+
+export function useTheme() {
+  onMounted(() => {
+    if (!initialized) {
+      colorSchemeMedia = window.matchMedia("(prefers-color-scheme: dark)");
+      colorSchemeMedia.addEventListener("change", onColorSchemeChange);
+
+      const colorSchemeLS = getColorSchemeLS();
+      if (colorSchemeLS) {
+        isDarkTheme.value = colorSchemeLS === "dark";
+      } else {
+        isDarkTheme.value = colorSchemeMedia.matches;
+      }
+
+      updateTheme(isDarkTheme.value);
+      initialized = true;
+    }
+  });
+
+  onUnmounted(() => {
+    // Only remove listener if we added it
+    // Note: In a real app with HMR, you might want more sophisticated cleanup
+  });
+
+  const toggleTheme = () => {
+    isDarkTheme.value = !isDarkTheme.value;
+    updateTheme(isDarkTheme.value);
+  };
+
+  const setTheme = (theme: "light" | "dark") => {
+    isDarkTheme.value = theme === "dark";
+    updateTheme(isDarkTheme.value);
+  };
+
+  return {
+    isDarkTheme,
+    toggleTheme,
+    setTheme,
+  };
+}

--- a/src/lib/components/overlay/Modal.vue
+++ b/src/lib/components/overlay/Modal.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { watch, onMounted, onUnmounted } from "vue";
+
+interface Props {
+  open: boolean;
+  closeOnBackdrop?: boolean;
+  closeOnEscape?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  closeOnBackdrop: true,
+  closeOnEscape: true,
+});
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const handleBackdropClick = (e: MouseEvent) => {
+  if (props.closeOnBackdrop && e.target === e.currentTarget) {
+    emit("close");
+  }
+};
+
+const handleKeydown = (e: KeyboardEvent) => {
+  if (props.closeOnEscape && e.key === "Escape" && props.open) {
+    emit("close");
+  }
+};
+
+onMounted(() => {
+  window.addEventListener("keydown", handleKeydown);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("keydown", handleKeydown);
+});
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+  },
+);
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div v-if="open" class="modal-backdrop" @click="handleBackdropClick">
+        <div class="modal-content">
+          <slot />
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 15vh;
+  z-index: var(--z-modal-backdrop);
+}
+
+.modal-content {
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-xl);
+  z-index: var(--z-modal);
+  max-height: 70vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Transition animations */
+.modal-enter-active,
+.modal-leave-active {
+  transition:
+    opacity var(--duration-medium) var(--ease-out),
+    transform var(--duration-medium) var(--ease-out);
+}
+
+.modal-enter-active .modal-content,
+.modal-leave-active .modal-content {
+  transition: transform var(--duration-medium) var(--ease-out);
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-from .modal-content,
+.modal-leave-to .modal-content {
+  transform: scale(0.95) translateY(-10px);
+}
+</style>

--- a/src/lib/components/overlay/index.ts
+++ b/src/lib/components/overlay/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from "./Modal.vue";

--- a/src/stores/commandPalette.ts
+++ b/src/stores/commandPalette.ts
@@ -1,0 +1,58 @@
+import { ref, computed, type Ref, type ComputedRef } from "vue";
+
+export interface Command {
+  id: string;
+  name: string;
+  description?: string;
+  shortcut?: string;
+  category?: string;
+  action: () => void;
+}
+
+const commands: Ref<Command[]> = ref([]);
+
+export const isCommandPaletteOpen: Ref<boolean> = ref(false);
+export const searchQuery: Ref<string> = ref("");
+export const selectedIndex: Ref<number> = ref(0);
+
+export const filteredCommands: ComputedRef<Command[]> = computed(() => {
+  const query = searchQuery.value.toLowerCase().trim();
+  if (!query) {
+    return commands.value;
+  }
+  return commands.value.filter(
+    (cmd) =>
+      cmd.name.toLowerCase().includes(query) ||
+      cmd.description?.toLowerCase().includes(query) ||
+      cmd.category?.toLowerCase().includes(query),
+  );
+});
+
+export function registerCommand(cmd: Command) {
+  // Avoid duplicates
+  if (!commands.value.find((c) => c.id === cmd.id)) {
+    commands.value.push(cmd);
+  }
+}
+
+export function unregisterCommand(id: string) {
+  const index = commands.value.findIndex((c) => c.id === id);
+  if (index !== -1) {
+    commands.value.splice(index, 1);
+  }
+}
+
+export function openCommandPalette() {
+  searchQuery.value = "";
+  selectedIndex.value = 0;
+  isCommandPaletteOpen.value = true;
+}
+
+export function closeCommandPalette() {
+  isCommandPaletteOpen.value = false;
+}
+
+export function executeCommand(cmd: Command) {
+  cmd.action();
+  closeCommandPalette();
+}

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -61,4 +61,7 @@ export const encodingMode: Ref<"hex" | "bin" | "dec"> = ref("hex");
 // advanced search data
 export * from "./advancedSearch";
 
+// command palette
+export * from "./commandPalette";
+
 export const symbolHtmlNamesMap: Ref<Map<number, string[]>> = ref(new Map<number, string[]>());


### PR DESCRIPTION
## Summary

- Create Modal component in design system
- Add command palette store with command registration
- Create useTheme and useGlobalKeyboard composables
- Move theme toggle from header to command palette
- Add toggle search mode command
- Prevent EasySearch auto-focus when palette is open