### PR TITLE
Add design system page and refine UI across the app

### DIFF
--- a/design-system/index.html
+++ b/design-system/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Design System - Unicode Lookup</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/design-system/main.ts"></script>
+  </body>
+</html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="manifest" href="/manifest.json" />
     <title>Unicode Lookup</title>
-    <script type="module" crossorigin src="/assets/index-BW8to3cp.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CtjIMKUN.css">
+    <script type="module" crossorigin src="/assets/main-Dff8Vm2P.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/main-D-Cx_0zz.css">
   </head>
   <body>
     <div id="app"></div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -47,8 +47,7 @@ onMounted(() => {
         <template v-if="hasFirstLoaded">
           <ResultsContainer v-if="results.length" />
           <template v-else>
-            <br />
-            <p>No results fit that query :/</p>
+            <p class="no-results">No results fit that query</p>
           </template>
         </template>
         <Loader v-else />
@@ -71,10 +70,12 @@ main {
   margin: 0 auto;
   width: 600px;
   max-width: 100%;
+  padding: 0 var(--space-4);
 }
 @media (min-width: 640px) {
   main {
     max-width: none;
+    padding: 0;
   }
 }
 .content.middle {
@@ -93,5 +94,11 @@ aside div {
   width: 400px;
   overflow-y: auto;
   height: 100vh;
+}
+.no-results {
+  color: var(--color-text-tertiary);
+  font-weight: 300;
+  letter-spacing: -0.01em;
+  padding: var(--space-4) 0;
 }
 </style>

--- a/src/components/CommandPalette.vue
+++ b/src/components/CommandPalette.vue
@@ -140,33 +140,36 @@ const handleItemHover = (index: number) => {
 
 <style scoped>
 .command-palette {
-  width: 500px;
+  width: 480px;
   max-width: 90vw;
 }
 
 .search-container {
-  padding: var(--space-3);
-  border-bottom: var(--border-width-1) solid var(--color-border);
+  padding: var(--space-4);
+  border-bottom: 1px solid rgba(128, 128, 128, 0.12);
 }
 
 .search-input {
   width: 100%;
   padding: var(--space-3) var(--space-4);
   border: none;
-  background: var(--color-bg-offset);
-  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  border-radius: var(--radius-lg);
   font-size: var(--font-size-base);
+  font-weight: 300;
   color: var(--color-text);
   outline: none;
   box-sizing: border-box;
+  letter-spacing: -0.01em;
 }
 
 .search-input::placeholder {
   color: var(--color-text-tertiary);
+  opacity: 0.6;
 }
 
 .command-list {
-  max-height: 400px;
+  max-height: 360px;
   overflow-y: auto;
   padding: var(--space-2);
 }
@@ -179,7 +182,7 @@ const handleItemHover = (index: number) => {
   padding: var(--space-3) var(--space-4);
   border: none;
   background: transparent;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   cursor: pointer;
   text-align: left;
   color: var(--color-text);
@@ -194,31 +197,36 @@ const handleItemHover = (index: number) => {
 .command-info {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: 2px;
 }
 
 .command-name {
-  font-weight: var(--font-weight-medium);
+  font-weight: 400;
   color: var(--color-text);
+  font-size: var(--font-size-sm);
 }
 
 .command-description {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   color: var(--color-text-tertiary);
+  font-weight: 300;
 }
 
 .command-shortcut {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
   background: var(--color-bg);
-  padding: var(--space-1) var(--space-2);
-  border-radius: var(--radius-sm);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-md);
   font-family: var(--font-family-mono);
+  border: 1px solid rgba(128, 128, 128, 0.12);
 }
 
 .no-results {
-  padding: var(--space-4);
+  padding: var(--space-6);
   text-align: center;
   color: var(--color-text-tertiary);
+  font-weight: 300;
+  font-size: var(--font-size-sm);
 }
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -28,12 +28,24 @@ header {
   display: flex;
   justify-content: space-between;
   max-width: 600px;
-  margin: var(--space-5) auto;
-  display: flex;
-  align-items: center;
+  margin: var(--space-8) auto var(--space-6);
+  align-items: baseline;
 }
 h1 {
-  font-size: 1.7em;
+  font-size: 1.5em;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+}
+h3 {
+  font-weight: 300;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+  letter-spacing: 0.01em;
+}
+.text {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
 }
 .buttons {
   display: flex;
@@ -42,15 +54,10 @@ button {
   cursor: pointer;
   margin: 0;
   z-index: 2;
-  padding: var(--space-3) var(--space-5);
+  padding: var(--space-2) var(--space-4);
 }
 .active {
   color: var(--hsl-bg);
   background: var(--hsl);
-  transition: 0.25s;
-}
-button:focus {
-  outline: var(--border-width-2) solid var(--color-border-focus);
-  outline-offset: var(--border-width-2);
 }
 </style>

--- a/src/components/Loader.vue
+++ b/src/components/Loader.vue
@@ -36,10 +36,18 @@ section {
   text-align: center;
   padding-top: var(--space-12);
 }
+h2 {
+  font-weight: 300;
+  font-size: var(--font-size-base);
+  color: var(--color-text-tertiary);
+  letter-spacing: 0.02em;
+  margin-bottom: var(--space-4);
+}
 .chars span {
   display: inline-block;
   width: var(--space-6);
   text-align: center;
   line-height: 1em;
+  opacity: 0.5;
 }
 </style>

--- a/src/components/ThemeSwitcher.vue
+++ b/src/components/ThemeSwitcher.vue
@@ -56,10 +56,14 @@ button {
   margin: 0;
   background: none;
   border: none;
-  padding: 0 10px;
-  opacity: 0.6;
+  padding: 0 var(--space-3);
+  opacity: 0.5;
+  transition: opacity var(--duration-fast) var(--ease-out);
+}
+button:hover {
+  opacity: 0.8;
 }
 button:active {
-  transform: scale(0.9);
+  transform: scale(0.92);
 }
 </style>

--- a/src/components/advanced-search/BoxContent.vue
+++ b/src/components/advanced-search/BoxContent.vue
@@ -65,32 +65,37 @@ function handleDataChange(data: any) {
 
 <style scoped>
 .content {
-  padding: var(--space-10);
+  padding: var(--space-8);
   display: grid;
   justify-content: center;
   margin-top: -1px;
   position: relative;
   z-index: 1;
   isolation: isolate;
+  border-radius: var(--radius-xl);
 }
 button {
   position: absolute;
-  top: var(--space-1);
+  top: var(--space-2);
   right: var(--space-3);
   background: none;
   border: none;
-  font-size: 2em;
+  font-size: 1.5em;
   padding: var(--space-1);
   line-height: 0.8em;
   margin: 0;
   z-index: 3;
   cursor: pointer;
+  opacity: 0.5;
+  transition: opacity var(--duration-fast);
 }
 button:hover {
-  opacity: 0.7;
+  opacity: 0.9;
 }
 hr {
-  margin: var(--space-3) calc(var(--space-10) * -1);
-  opacity: 0.4;
+  margin: var(--space-3) calc(var(--space-8) * -1);
+  opacity: 0.2;
+  border: none;
+  border-top: 1px solid currentColor;
 }
 </style>

--- a/src/components/advanced-search/Button.vue
+++ b/src/components/advanced-search/Button.vue
@@ -27,27 +27,19 @@ const btnClass = computed(() => ["styled", props.disabled && "disabled"].filter(
 <style scoped>
 button {
   margin: 0;
-  padding: var(--space-2) var(--space-4);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
+  padding: var(--space-2) var(--space-5);
+  border-radius: var(--radius-lg);
+  box-shadow: none;
   cursor: pointer;
-}
-button:focus {
-  outline: var(--border-width-2) solid var(--color-border-focus);
-  outline-offset: var(--border-width-2);
+  font-weight: 400;
 }
 button:active {
-  color: var(--hsl);
-  border: var(--border-width-1) solid var(--hsl);
-  background: hsl(var(--hue), 100%, 95%);
-}
-button:active {
-  background: hsl(var(--hue), 70%, 95%);
-  transform: scale(0.95);
+  transform: scale(0.97);
 }
 .disabled {
   border: 1px solid hsl(var(--hue), 40%, 75%);
   color: hsl(var(--hue), 40%, 75%);
   cursor: auto;
+  opacity: 0.6;
 }
 </style>

--- a/src/components/advanced-search/Dropdown.vue
+++ b/src/components/advanced-search/Dropdown.vue
@@ -41,16 +41,12 @@ function handleChange(e: Event) {
 
 <style scoped>
 select {
-  box-shadow: var(--shadow-sm);
+  box-shadow: none;
   cursor: pointer;
-}
-select:focus {
-  outline: var(--border-width-2) solid var(--color-border-focus);
-  outline-offset: var(--border-width-2);
+  font-weight: 400;
 }
 select:disabled {
-  opacity: 1;
-  filter: brightness(95%);
+  opacity: 0.6;
   cursor: auto;
 }
 </style>

--- a/src/components/advanced-search/Input.vue
+++ b/src/components/advanced-search/Input.vue
@@ -68,6 +68,9 @@ function handleInput(e: Event) {
 
 <style scoped>
 p {
-  color: red;
+  color: var(--color-error);
+  font-size: var(--font-size-xs);
+  margin-top: var(--space-1);
+  font-weight: 400;
 }
 </style>

--- a/src/components/advanced-search/NumberInput.vue
+++ b/src/components/advanced-search/NumberInput.vue
@@ -95,6 +95,9 @@ function handleInput(e: Event) {
 <style scoped>
 p {
   margin: 0;
-  color: red;
+  color: var(--color-error);
+  font-size: var(--font-size-xs);
+  margin-top: var(--space-1);
+  font-weight: 400;
 }
 </style>

--- a/src/components/table-container/InfoContainer.vue
+++ b/src/components/table-container/InfoContainer.vue
@@ -103,38 +103,51 @@ const htmlEntityNames = computed(() => symbolHtmlNamesMap.value.get(props.codepo
 
 <style scoped>
 div.container {
-  border-radius: var(--radius-xl);
-  padding: var(--space-5);
+  border-radius: 0;
+  padding: var(--space-6) var(--space-5);
 }
 .basic-info {
   display: grid;
+  font-size: var(--font-size-sm);
 }
 td {
-  padding: var(--space-2);
+  padding: var(--space-2) var(--space-3);
 }
 td:nth-child(1) {
-  font-weight: bold;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+td:nth-child(2) {
+  color: var(--color-text);
 }
 tr:nth-child(odd) {
-  background-color: var(--bg-offset);
+  background-color: var(--color-bg-offset);
+  border-radius: var(--radius-sm);
 }
 h1 {
   text-align: center;
+  font-size: var(--font-size-lg);
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
 }
 .display-box {
-  background-color: var(--bg-offset);
-  height: 64px;
-  width: 64px;
-  font-size: 3em;
-  border: var(--border-width-1) solid var(--color-border);
+  background-color: var(--color-bg-offset);
+  height: 72px;
+  width: 72px;
+  font-size: 2.5em;
+  border: 1px solid rgba(128, 128, 128, 0.15);
+  border-radius: var(--radius-xl);
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: var(--space-3) 0;
+  margin: var(--space-4) 0;
 }
 header {
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-bottom: var(--space-4);
 }
 </style>

--- a/src/components/table-container/ResultsContainer.vue
+++ b/src/components/table-container/ResultsContainer.vue
@@ -79,9 +79,11 @@ function handleKeydown(e: KeyboardEvent) {
 }
 p {
   text-align: left;
-  margin: 0;
-  opacity: 0.7;
-  font-size: 0.8rem;
+  margin: 0 0 var(--space-3);
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+  font-weight: 400;
+  letter-spacing: 0.02em;
 }
 .intersection-observer {
   height: 5rem;

--- a/src/components/table-container/ResultsRow.vue
+++ b/src/components/table-container/ResultsRow.vue
@@ -78,8 +78,16 @@ watch(
 .row {
   border: 1px solid transparent;
   width: 100%;
-  background-color: var(--bg-offset);
+  background-color: var(--color-bg-offset);
   position: relative;
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-1);
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    background-color var(--duration-fast) var(--ease-out);
+}
+.row:hover {
+  box-shadow: inset 0 0 0 1px var(--color-border);
 }
 .row:after {
   content: attr(data-codepoint);
@@ -87,30 +95,39 @@ watch(
   position: absolute;
   bottom: 0;
   right: 0;
-  padding: 0.5rem;
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text-tertiary);
   opacity: 0.5;
-  font-size: 0.8rem;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-family-mono);
+  letter-spacing: 0.02em;
 }
 .row.active {
-  border: var(--border-width-1) solid var(--color-border-focus);
+  border-color: var(--color-border-focus);
+  box-shadow: 0 0 0 2px rgba(123, 142, 230, 0.2);
 }
 .content {
   width: 100%;
-  padding: 0.5rem;
+  padding: var(--space-3) var(--space-3);
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 1rem;
+  gap: var(--space-4);
+  align-items: center;
 }
 .symbol {
   width: 2rem;
   text-align: center;
+  font-size: var(--font-size-lg);
 }
 .symbol::before,
 .symbol::after {
   content: '"';
+  opacity: 0.3;
 }
 .name {
   text-align: left;
-  opacity: 0.75;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.005em;
 }
 </style>

--- a/src/components/table-container/info-tables/Encoding.vue
+++ b/src/components/table-container/info-tables/Encoding.vue
@@ -79,40 +79,54 @@ function setEncoding(encoding: EncodingType) {
 <style scoped>
 .bit-sets span {
   padding: 0 3px;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
 }
 .title {
-  color: var(--label-col);
-  font-weight: bold;
+  color: var(--color-text-secondary);
+  font-weight: 500;
 }
 td {
-  padding: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-sm);
+}
+td:first-child {
+  color: var(--color-text-secondary);
+  font-weight: 500;
+  white-space: nowrap;
 }
 th:first-child {
-  color: var(--primary-text);
+  color: var(--color-text-primary);
   font-weight: 400;
+  font-size: var(--font-size-sm);
   padding-right: var(--space-4);
 }
 tbody tr:nth-child(odd) {
-  background-color: var(--bg-offset);
+  background-color: var(--color-bg-offset);
 }
 .encoding-type {
   display: flex;
+  gap: 2px;
 }
 .encoding-type button {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: pointer;
-  padding: var(--space-2);
+  padding: var(--space-1) var(--space-2);
   border: none;
   background: 0;
   margin: 0;
-  font-weight: 600;
+  font-weight: 500;
+  font-size: var(--font-size-xs);
+  border-radius: var(--radius-md);
+  transition:
+    opacity var(--duration-fast),
+    background var(--duration-fast);
 }
-.encoding-type button:focus {
-  outline: var(--border-width-2) solid var(--color-border-focus);
-  outline-offset: var(--border-width-2);
+.encoding-type button:hover {
+  opacity: 0.8;
 }
 .encoding-type .active {
-  opacity: 0.95;
+  opacity: 1;
   background-color: var(--color-bg-active);
 }
 </style>

--- a/src/components/table-container/info-tables/HtmlEntities.vue
+++ b/src/components/table-container/info-tables/HtmlEntities.vue
@@ -37,17 +37,24 @@ const props = defineProps<Props>();
 <style scoped>
 th {
   text-align: left;
-  color: var(--primary-text);
+  color: var(--color-text-primary);
   font-weight: 400;
+  font-size: var(--font-size-sm);
   padding-bottom: var(--space-2);
 }
 tbody tr:nth-child(odd) {
-  background-color: var(--bg-offset);
+  background-color: var(--color-bg-offset);
 }
 td {
-  padding: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-sm);
 }
 td:first-child {
   padding-right: var(--space-8);
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+td:nth-child(2) {
+  font-family: var(--font-family-mono);
 }
 </style>

--- a/src/components/table-container/info-tables/Properties.vue
+++ b/src/components/table-container/info-tables/Properties.vue
@@ -17,10 +17,11 @@ const props = defineProps<Props>();
 
 <style scoped>
 h3 {
-  padding-bottom: var(--space-2);
-  color: var(--primary-text);
-  font-size: 1rem;
+  padding-bottom: var(--space-3);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
   font-weight: 400;
+  letter-spacing: 0.01em;
 }
 .properties {
   width: 100%;
@@ -28,11 +29,14 @@ h3 {
   flex-wrap: wrap;
   gap: var(--space-1);
   text-align: left;
-  margin-bottom: var(--space-8);
+  margin-bottom: var(--space-6);
 }
 .properties span {
-  background: var(--bg-offset);
+  background: var(--color-bg-offset);
   padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-md);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  border: 1px solid rgba(128, 128, 128, 0.1);
 }
 </style>

--- a/src/design-system/App.vue
+++ b/src/design-system/App.vue
@@ -1,0 +1,1356 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from "vue";
+import { useTheme } from "$src/composables";
+import SunIcon from "$icons/SunIcon.vue";
+
+import Button from "$lib/components/forms/Button.vue";
+import Input from "$lib/components/forms/Input.vue";
+import TextArea from "$lib/components/forms/TextArea.vue";
+import Select from "$lib/components/forms/Select.vue";
+import Checkbox from "$lib/components/forms/Checkbox.vue";
+import Radio from "$lib/components/forms/Radio.vue";
+import Switch from "$lib/components/forms/Switch.vue";
+import Label from "$lib/components/forms/Label.vue";
+import Alert from "$lib/components/feedback/Alert.vue";
+import Badge from "$lib/components/feedback/Badge.vue";
+import Spinner from "$lib/components/feedback/Spinner.vue";
+import Modal from "$lib/components/overlay/Modal.vue";
+import Heading from "$lib/components/typography/Heading.vue";
+import Text from "$lib/components/typography/Text.vue";
+
+const { toggleTheme, isDarkTheme } = useTheme();
+
+const inputValue = ref("");
+const textareaValue = ref("");
+const selectValue = ref("");
+const checkboxValue = ref(false);
+const checkboxIndeterminate = ref(true);
+const radioValue = ref("a");
+const switchValue = ref(false);
+const switchOn = ref(true);
+const modalOpen = ref(false);
+const activeSection = ref("colors");
+
+const sections = [
+  { id: "colors", label: "Colors" },
+  { id: "typography", label: "Typography" },
+  { id: "spacing", label: "Spacing" },
+  { id: "shadows", label: "Shadows" },
+  { id: "radius", label: "Radius" },
+  { id: "buttons", label: "Buttons" },
+  { id: "inputs", label: "Inputs" },
+  { id: "textarea", label: "TextArea" },
+  { id: "select", label: "Select" },
+  { id: "controls", label: "Controls" },
+  { id: "labels", label: "Labels" },
+  { id: "alerts", label: "Alerts" },
+  { id: "badges", label: "Badges" },
+  { id: "spinners", label: "Spinners" },
+  { id: "modal", label: "Modal" },
+];
+
+function handleIntersection(entries: IntersectionObserverEntry[]) {
+  for (const entry of entries) {
+    if (entry.isIntersecting) {
+      activeSection.value = entry.target.id;
+    }
+  }
+}
+
+let observer: IntersectionObserver | null = null;
+
+onMounted(() => {
+  observer = new IntersectionObserver(handleIntersection, {
+    rootMargin: "-20% 0px -70% 0px",
+  });
+  for (const s of sections) {
+    const el = document.getElementById(s.id);
+    if (el) observer.observe(el);
+  }
+});
+
+onUnmounted(() => {
+  observer?.disconnect();
+});
+</script>
+
+<template>
+  <div class="layout">
+    <nav class="sidebar">
+      <div class="sidebar-inner">
+        <a href="#" class="sidebar-brand">
+          <span class="sidebar-brand-mark">DS</span>
+          <span class="sidebar-brand-text">Design System</span>
+        </a>
+        <ul class="sidebar-nav">
+          <li class="sidebar-group-label">Foundations</li>
+          <li v-for="s in sections.slice(0, 5)" :key="s.id">
+            <a
+              :href="`#${s.id}`"
+              :class="['sidebar-link', activeSection === s.id && 'sidebar-link--active']"
+              >{{ s.label }}</a
+            >
+          </li>
+          <li class="sidebar-group-label">Components</li>
+          <li v-for="s in sections.slice(5)" :key="s.id">
+            <a
+              :href="`#${s.id}`"
+              :class="['sidebar-link', activeSection === s.id && 'sidebar-link--active']"
+              >{{ s.label }}</a
+            >
+          </li>
+        </ul>
+        <button class="theme-toggle" @click="toggleTheme">
+          <SunIcon />
+          <span>{{ isDarkTheme ? "Dark" : "Light" }}</span>
+        </button>
+      </div>
+    </nav>
+
+    <main class="content">
+      <div class="content-header">
+        <p class="page-eyebrow">Unicode Lookup</p>
+        <h1 class="page-title">Design System</h1>
+        <p class="page-subtitle">
+          A reference of every token, primitive, and component available in the project.
+        </p>
+        <div class="header-rule" />
+      </div>
+
+      <!-- Colors -->
+      <section id="colors" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Colors</h2>
+          <p class="section-desc">HSL-based color system with light and dark theme support.</p>
+        </div>
+
+        <div class="card">
+          <h3 class="card-label">Theme</h3>
+          <div class="swatch-row">
+            <div
+              v-for="c in [
+                { var: 'color-bg', label: 'bg' },
+                { var: 'color-bg-offset', label: 'bg-offset' },
+                { var: 'color-bg-elevated', label: 'bg-elevated' },
+                { var: 'color-bg-input', label: 'bg-input' },
+              ]"
+              :key="c.var"
+              class="swatch"
+            >
+              <div class="swatch-fill" :style="{ background: `var(--${c.var})` }" />
+              <span class="swatch-name">{{ c.label }}</span>
+            </div>
+          </div>
+          <div class="swatch-row">
+            <div
+              v-for="c in [
+                { var: 'color-text', label: 'text' },
+                { var: 'color-text-secondary', label: 'text-secondary' },
+                { var: 'color-text-tertiary', label: 'text-tertiary' },
+                { var: 'color-text-primary', label: 'text-primary' },
+              ]"
+              :key="c.var"
+              class="swatch"
+            >
+              <div class="swatch-fill" :style="{ background: `var(--${c.var})` }" />
+              <span class="swatch-name">{{ c.label }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3 class="card-label">Primary</h3>
+          <div class="swatch-row">
+            <div
+              v-for="c in [
+                { var: 'color-primary', label: 'primary' },
+                { var: 'color-primary-bg', label: 'primary-bg' },
+                { var: 'color-primary-hover', label: 'primary-hover' },
+                { var: 'color-primary-active', label: 'primary-active' },
+              ]"
+              :key="c.var"
+              class="swatch"
+            >
+              <div class="swatch-fill" :style="{ background: `var(--${c.var})` }" />
+              <span class="swatch-name">{{ c.label }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3 class="card-label">Semantic</h3>
+          <div class="semantic-grid">
+            <div
+              v-for="name in ['success', 'warning', 'error', 'info']"
+              :key="name"
+              class="semantic-pair"
+            >
+              <div class="semantic-fills">
+                <div
+                  class="swatch-fill swatch-fill--sm"
+                  :style="{ background: `var(--color-${name})` }"
+                />
+                <div
+                  class="swatch-fill swatch-fill--sm"
+                  :style="{
+                    background: `var(--color-${name}-bg)`,
+                    border: `1px solid var(--color-${name}-border)`,
+                  }"
+                />
+              </div>
+              <span class="swatch-name">{{ name }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3 class="card-label">Border &amp; Link</h3>
+          <div class="swatch-row">
+            <div
+              v-for="c in [
+                { var: 'color-border', label: 'border' },
+                { var: 'color-border-focus', label: 'border-focus' },
+                { var: 'color-link', label: 'link' },
+                { var: 'color-link-visited', label: 'link-visited' },
+              ]"
+              :key="c.var"
+              class="swatch"
+            >
+              <div class="swatch-fill" :style="{ background: `var(--${c.var})` }" />
+              <span class="swatch-name">{{ c.label }}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Typography -->
+      <section id="typography" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Typography</h2>
+          <p class="section-desc">System font stack with a harmonious type scale.</p>
+        </div>
+
+        <div class="card">
+          <h3 class="card-label">Headings</h3>
+          <div class="type-scale">
+            <div v-for="h in [1, 2, 3, 4, 5, 6]" :key="h" class="type-scale-row">
+              <Heading :level="h as any">Heading {{ h }}</Heading>
+              <span class="type-meta">h{{ h }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="card-row">
+          <div class="card card--flush">
+            <h3 class="card-label">Sizes</h3>
+            <div class="type-list">
+              <div
+                v-for="s in [
+                  { size: '4xl', px: '36' },
+                  { size: '3xl', px: '30' },
+                  { size: '2xl', px: '24' },
+                  { size: 'xl', px: '20' },
+                  { size: 'lg', px: '18' },
+                  { size: 'base', px: '16' },
+                  { size: 'sm', px: '14' },
+                  { size: 'xs', px: '12' },
+                ]"
+                :key="s.size"
+                class="type-row"
+              >
+                <Text :size="s.size as any" as="span">Aa</Text>
+                <span class="type-meta"
+                  >{{ s.size }}<span class="type-dim"> / {{ s.px }}px</span></span
+                >
+              </div>
+            </div>
+          </div>
+
+          <div class="card card--flush">
+            <h3 class="card-label">Weights</h3>
+            <div class="type-list">
+              <div
+                v-for="w in [
+                  { weight: 'normal', value: '400' },
+                  { weight: 'medium', value: '500' },
+                  { weight: 'semibold', value: '600' },
+                  { weight: 'bold', value: '700' },
+                ]"
+                :key="w.weight"
+                class="type-row"
+              >
+                <Text :weight="w.weight as any" size="lg" as="span">The quick brown fox</Text>
+                <span class="type-meta"
+                  >{{ w.weight }}<span class="type-dim"> / {{ w.value }}</span></span
+                >
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3 class="card-label">Colors</h3>
+          <div class="type-colors">
+            <div
+              v-for="c in [
+                { color: 'base', label: 'Base' },
+                { color: 'secondary', label: 'Secondary' },
+                { color: 'tertiary', label: 'Tertiary' },
+                { color: 'primary', label: 'Primary' },
+                { color: 'error', label: 'Error' },
+                { color: 'success', label: 'Success' },
+              ]"
+              :key="c.color"
+              class="type-color-item"
+            >
+              <Text :color="c.color as any" size="lg">{{ c.label }} text color</Text>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Spacing -->
+      <section id="spacing" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Spacing</h2>
+          <p class="section-desc">4px base unit scale for consistent spatial rhythm.</p>
+        </div>
+
+        <div class="card">
+          <div class="spacing-list">
+            <div
+              v-for="s in [
+                { key: 1, px: 4 },
+                { key: 2, px: 8 },
+                { key: 3, px: 12 },
+                { key: 4, px: 16 },
+                { key: 5, px: 20 },
+                { key: 6, px: 24 },
+                { key: 8, px: 32 },
+                { key: 10, px: 40 },
+                { key: 12, px: 48 },
+                { key: 16, px: 64 },
+                { key: 20, px: 80 },
+              ]"
+              :key="s.key"
+              class="spacing-row"
+            >
+              <span class="spacing-label">{{ s.key }}</span>
+              <div class="spacing-track">
+                <div class="spacing-bar" :style="{ width: `var(--space-${s.key})` }" />
+              </div>
+              <span class="spacing-px">{{ s.px }}px</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Shadows -->
+      <section id="shadows" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Shadows</h2>
+          <p class="section-desc">Elevation system for layering and depth.</p>
+        </div>
+
+        <div class="card">
+          <div class="shadow-strip">
+            <div v-for="s in ['xs', 'sm', 'base', 'md', 'lg', 'xl']" :key="s" class="shadow-item">
+              <div class="shadow-box" :style="{ boxShadow: `var(--shadow-${s})` }" />
+              <span class="shadow-label">{{ s }}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Border Radius -->
+      <section id="radius" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Border Radius</h2>
+          <p class="section-desc">Corner rounding tokens from sharp to pill.</p>
+        </div>
+
+        <div class="card">
+          <div class="radius-strip">
+            <div
+              v-for="r in [
+                { key: 'none', px: '0' },
+                { key: 'sm', px: '2' },
+                { key: 'base', px: '3' },
+                { key: 'md', px: '4' },
+                { key: 'lg', px: '6' },
+                { key: 'xl', px: '8' },
+                { key: '2xl', px: '12' },
+                { key: 'full', px: '9999' },
+              ]"
+              :key="r.key"
+              class="radius-item"
+            >
+              <div class="radius-shape" :style="{ borderRadius: `var(--radius-${r.key})` }" />
+              <span class="radius-label">{{ r.key }}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Buttons -->
+      <section id="buttons" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Buttons</h2>
+          <p class="section-desc">Action triggers with multiple variants and sizes.</p>
+        </div>
+
+        <div class="card">
+          <h3 class="card-label">Variants</h3>
+          <div class="demo-row">
+            <Button variant="primary">Primary</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="outline">Outline</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="danger">Danger</Button>
+          </div>
+        </div>
+
+        <div class="card-row">
+          <div class="card card--flush">
+            <h3 class="card-label">Sizes</h3>
+            <div class="demo-row demo-row--center">
+              <Button size="sm">Small</Button>
+              <Button size="base">Base</Button>
+              <Button size="lg">Large</Button>
+            </div>
+          </div>
+
+          <div class="card card--flush">
+            <h3 class="card-label">States</h3>
+            <div class="demo-row demo-row--center">
+              <Button disabled>Disabled</Button>
+              <Button loading>Loading</Button>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3 class="card-label">Custom Hue</h3>
+          <div class="demo-row">
+            <Button :hue="0">Red (0)</Button>
+            <Button :hue="30">Orange (30)</Button>
+            <Button :hue="120">Green (120)</Button>
+            <Button :hue="200">Blue (200)</Button>
+            <Button :hue="270">Purple (270)</Button>
+            <Button :hue="330">Pink (330)</Button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3 class="card-label">Full Width</h3>
+          <Button full-width>Full Width Button</Button>
+        </div>
+      </section>
+
+      <!-- Inputs -->
+      <section id="inputs" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Inputs</h2>
+          <p class="section-desc">Text input fields with validation and size variants.</p>
+        </div>
+
+        <div class="card-row">
+          <div class="card card--flush">
+            <h3 class="card-label">Sizes</h3>
+            <div class="field-stack">
+              <Input size="sm" placeholder="Small input" full-width />
+              <Input size="base" placeholder="Base input" full-width />
+              <Input size="lg" placeholder="Large input" full-width />
+            </div>
+          </div>
+
+          <div class="card card--flush">
+            <h3 class="card-label">States</h3>
+            <div class="field-stack">
+              <div>
+                <Label size="sm">Default</Label>
+                <Input v-model="inputValue" placeholder="Type something..." full-width />
+              </div>
+              <div>
+                <Label size="sm">Error</Label>
+                <Input model-value="bad value" error="This field is required" full-width />
+              </div>
+              <div>
+                <Label size="sm">Disabled</Label>
+                <Input model-value="Can't edit" disabled full-width />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- TextArea -->
+      <section id="textarea" class="section">
+        <div class="section-header">
+          <h2 class="section-title">TextArea</h2>
+          <p class="section-desc">Multi-line text input with resize control.</p>
+        </div>
+
+        <div class="card-row">
+          <div class="card card--flush">
+            <div class="field-stack">
+              <div>
+                <Label size="sm">Default</Label>
+                <TextArea
+                  v-model="textareaValue"
+                  placeholder="Write something..."
+                  full-width
+                  :rows="3"
+                />
+              </div>
+            </div>
+          </div>
+          <div class="card card--flush">
+            <div class="field-stack">
+              <div>
+                <Label size="sm">With Error</Label>
+                <TextArea model-value="oops" error="Content is too short" full-width :rows="3" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Select -->
+      <section id="select" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Select</h2>
+          <p class="section-desc">Dropdown selection menus.</p>
+        </div>
+
+        <div class="card">
+          <div class="demo-row">
+            <div class="field-group">
+              <Label size="sm">Default</Label>
+              <Select
+                v-model="selectValue"
+                :options="['Apple', 'Banana', 'Cherry']"
+                placeholder="Pick a fruit"
+              />
+            </div>
+            <div class="field-group">
+              <Label size="sm">Small</Label>
+              <Select size="sm" :options="['A', 'B', 'C']" placeholder="Pick" />
+            </div>
+            <div class="field-group">
+              <Label size="sm">Error</Label>
+              <Select :options="['X']" error="Required" />
+            </div>
+            <div class="field-group">
+              <Label size="sm">Disabled</Label>
+              <Select :options="['Locked']" disabled />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Checkbox, Radio, Switch -->
+      <section id="controls" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Controls</h2>
+          <p class="section-desc">Toggle and selection controls.</p>
+        </div>
+
+        <div class="card-row card-row--thirds">
+          <div class="card card--flush">
+            <h3 class="card-label">Checkbox</h3>
+            <div class="control-stack">
+              <Checkbox v-model="checkboxValue" label="Default" />
+              <Checkbox :model-value="true" label="Checked" />
+              <Checkbox
+                :model-value="false"
+                :indeterminate="checkboxIndeterminate"
+                label="Indeterminate"
+              />
+              <Checkbox disabled label="Disabled" />
+              <Checkbox :model-value="false" error="Required" label="Error" />
+            </div>
+          </div>
+
+          <div class="card card--flush">
+            <h3 class="card-label">Radio</h3>
+            <div class="control-stack">
+              <Radio v-model="radioValue" name="demo" value="a" label="Option A" />
+              <Radio v-model="radioValue" name="demo" value="b" label="Option B" />
+              <Radio v-model="radioValue" name="demo" value="c" label="Option C" />
+              <Radio name="demo-d" value="x" label="Disabled" disabled />
+            </div>
+          </div>
+
+          <div class="card card--flush">
+            <h3 class="card-label">Switch</h3>
+            <div class="control-stack">
+              <Switch v-model="switchValue" label="Off" />
+              <Switch v-model="switchOn" label="On" />
+              <Switch size="sm" label="Small" />
+              <Switch size="lg" label="Large" />
+              <Switch disabled label="Disabled" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Labels -->
+      <section id="labels" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Labels</h2>
+          <p class="section-desc">Form field labels with optional/required indicators.</p>
+        </div>
+
+        <div class="card">
+          <div class="demo-row demo-row--center">
+            <Label>Default</Label>
+            <Label required>Required</Label>
+            <Label optional>Optional</Label>
+            <Label size="sm">Small</Label>
+            <Label size="lg">Large</Label>
+          </div>
+        </div>
+      </section>
+
+      <!-- Alerts -->
+      <section id="alerts" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Alerts</h2>
+          <p class="section-desc">Contextual feedback messages for user actions.</p>
+        </div>
+
+        <div class="card">
+          <div class="alert-stack">
+            <Alert variant="info" title="Information"
+              >This is an informational message with helpful context.</Alert
+            >
+            <Alert variant="success" title="Success">The operation completed successfully.</Alert>
+            <Alert variant="warning" title="Warning"
+              >Please review your input before proceeding.</Alert
+            >
+            <Alert variant="error" title="Error">Something went wrong. Please try again.</Alert>
+            <Alert variant="info" dismissible>Dismissible alert -- click the close button.</Alert>
+          </div>
+        </div>
+      </section>
+
+      <!-- Badges -->
+      <section id="badges" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Badges</h2>
+          <p class="section-desc">Compact status indicators and labels.</p>
+        </div>
+
+        <div class="card">
+          <h3 class="card-label">Variants</h3>
+          <div class="demo-row">
+            <Badge>Default</Badge>
+            <Badge variant="primary">Primary</Badge>
+            <Badge variant="success">Success</Badge>
+            <Badge variant="warning">Warning</Badge>
+            <Badge variant="error">Error</Badge>
+            <Badge variant="info">Info</Badge>
+          </div>
+        </div>
+
+        <div class="card-row">
+          <div class="card card--flush">
+            <h3 class="card-label">Sizes</h3>
+            <div class="demo-row demo-row--center">
+              <Badge size="sm">Small</Badge>
+              <Badge size="base">Base</Badge>
+              <Badge size="lg">Large</Badge>
+            </div>
+          </div>
+
+          <div class="card card--flush">
+            <h3 class="card-label">Options</h3>
+            <div class="demo-row demo-row--center">
+              <Badge pill variant="primary">Pill</Badge>
+              <Badge dot variant="success">Dot</Badge>
+              <Badge pill dot variant="error">Pill + Dot</Badge>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Spinners -->
+      <section id="spinners" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Spinners</h2>
+          <p class="section-desc">Loading indicators for async operations.</p>
+        </div>
+
+        <div class="card">
+          <div class="demo-row demo-row--center" style="gap: var(--space-8)">
+            <div class="spinner-demo">
+              <Spinner size="sm" />
+              <span class="mono-label">sm</span>
+            </div>
+            <div class="spinner-demo">
+              <Spinner size="base" />
+              <span class="mono-label">base</span>
+            </div>
+            <div class="spinner-demo">
+              <Spinner size="lg" />
+              <span class="mono-label">lg</span>
+            </div>
+            <div class="spinner-demo">
+              <Spinner size="xl" />
+              <span class="mono-label">xl</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Modal -->
+      <section id="modal" class="section">
+        <div class="section-header">
+          <h2 class="section-title">Modal</h2>
+          <p class="section-desc">Overlay dialog for focused interactions.</p>
+        </div>
+
+        <div class="card">
+          <Button variant="outline" @click="modalOpen = true">Open Modal</Button>
+          <Modal :open="modalOpen" @close="modalOpen = false">
+            <div class="modal-demo">
+              <Heading :level="3" size="lg">Dialog Title</Heading>
+              <Text color="secondary">Click outside or press Escape to close this dialog.</Text>
+              <div class="modal-actions">
+                <Button variant="ghost" @click="modalOpen = false">Cancel</Button>
+                <Button @click="modalOpen = false">Confirm</Button>
+              </div>
+            </div>
+          </Modal>
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<style>
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap");
+
+body {
+  overflow-y: scroll;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+</style>
+
+<style scoped>
+/* ============================================
+   LAYOUT
+   ============================================ */
+.layout {
+  display: flex;
+  min-height: 100vh;
+  font-family: "Inter", var(--font-family-base);
+}
+
+/* ============================================
+   SIDEBAR
+   ============================================ */
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 210px;
+  height: 100vh;
+  background: var(--color-bg);
+  z-index: var(--z-sticky);
+  border-right: none;
+}
+
+.sidebar-inner {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: var(--space-8) 0 var(--space-6);
+  overflow-y: auto;
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 0 var(--space-6);
+  margin-bottom: var(--space-8);
+  text-decoration: none;
+}
+
+.sidebar-brand:hover {
+  text-decoration: none;
+}
+
+.sidebar-brand-mark {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-primary);
+  color: white;
+  border-radius: var(--radius-md);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.sidebar-brand-text {
+  font-size: var(--font-size-sm);
+  font-weight: 400;
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+}
+
+.sidebar-nav {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex: 1;
+}
+
+.sidebar-group-label {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: var(--space-4) var(--space-6) var(--space-2);
+}
+
+.sidebar-link {
+  display: block;
+  padding: 6px var(--space-6);
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+  text-decoration: none;
+  transition: color var(--duration-fast) var(--ease-out);
+  letter-spacing: -0.005em;
+}
+
+.sidebar-link:visited {
+  color: var(--color-text-tertiary);
+}
+
+.sidebar-link:hover {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.sidebar-link--active {
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.sidebar-link--active:visited {
+  color: var(--color-text);
+}
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-4) var(--space-5) 0;
+  padding: 6px var(--space-3);
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-tertiary);
+  font-size: 13px;
+  font-weight: 400;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast),
+    background var(--duration-fast);
+  font-family: "Inter", var(--font-family-base);
+}
+
+.theme-toggle:hover {
+  color: var(--color-text);
+  background: var(--color-bg-active);
+}
+
+.theme-toggle :deep(svg) {
+  width: 14px;
+  height: 14px;
+  opacity: 0.7;
+}
+
+/* ============================================
+   CONTENT
+   ============================================ */
+.content {
+  flex: 1;
+  margin-left: 210px;
+  padding: var(--space-12) var(--space-12) var(--space-20);
+  max-width: 820px;
+}
+
+/* ============================================
+   PAGE HEADER
+   ============================================ */
+.content-header {
+  margin-bottom: var(--space-16);
+}
+
+.page-eyebrow {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin: 0 0 var(--space-3);
+}
+
+.page-title {
+  font-size: 2.75rem;
+  font-weight: 300;
+  color: var(--color-text);
+  letter-spacing: -0.035em;
+  line-height: 1.1;
+  margin: 0;
+}
+
+.page-subtitle {
+  margin: var(--space-4) 0 0;
+  font-size: var(--font-size-base);
+  font-weight: 300;
+  color: var(--color-text-tertiary);
+  line-height: var(--line-height-relaxed);
+  max-width: 480px;
+}
+
+.header-rule {
+  width: 40px;
+  height: 1px;
+  background: var(--color-border);
+  margin-top: var(--space-8);
+}
+
+/* ============================================
+   SECTIONS
+   ============================================ */
+.section {
+  margin-bottom: var(--space-16);
+  scroll-margin-top: var(--space-8);
+}
+
+.section-header {
+  margin-bottom: var(--space-6);
+}
+
+.section-title {
+  font-size: var(--font-size-lg);
+  font-weight: 400;
+  color: var(--color-text);
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.section-desc {
+  margin: var(--space-1) 0 0;
+  font-size: 13px;
+  font-weight: 300;
+  color: var(--color-text-tertiary);
+}
+
+/* ============================================
+   CARDS
+   ============================================ */
+.card {
+  background: transparent;
+  border: none;
+  border-top: 1px solid var(--color-border);
+  border-radius: 0;
+  padding: var(--space-6) 0;
+  margin-bottom: 0;
+}
+
+.card-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 var(--space-5);
+}
+
+.card-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 var(--space-10);
+  border-top: 1px solid var(--color-border);
+}
+
+.card-row--thirds {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.card--flush {
+  border-top: none;
+  padding-top: var(--space-6);
+  margin-bottom: 0;
+}
+
+/* ============================================
+   COLOR SWATCHES
+   ============================================ */
+.swatch-row {
+  display: flex;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+}
+
+.swatch-row:last-child {
+  margin-bottom: 0;
+}
+
+.swatch {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.swatch-fill {
+  height: 44px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(128, 128, 128, 0.12);
+  transition:
+    transform var(--duration-base) var(--ease-out),
+    box-shadow var(--duration-base) var(--ease-out);
+}
+
+.swatch:hover .swatch-fill {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.swatch-fill--sm {
+  height: 28px;
+}
+
+.swatch-name {
+  font-size: 10.5px;
+  font-family: var(--font-family-mono);
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+  letter-spacing: 0.01em;
+}
+
+.semantic-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-5);
+}
+
+.semantic-pair {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.semantic-fills {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+/* ============================================
+   TYPOGRAPHY DEMOS
+   ============================================ */
+.type-scale {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.type-scale-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.06);
+}
+
+.type-scale-row:last-child {
+  border-bottom: none;
+}
+
+.type-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.type-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.06);
+}
+
+.type-row:last-child {
+  border-bottom: none;
+}
+
+.type-meta {
+  font-size: 11px;
+  font-family: var(--font-family-mono);
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+}
+
+.type-dim {
+  opacity: 0.5;
+}
+
+.type-colors {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+}
+
+.type-color-item {
+  padding: var(--space-3) 0;
+}
+
+/* ============================================
+   SPACING
+   ============================================ */
+.spacing-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.spacing-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 5px 0;
+  transition: background var(--duration-fast);
+  border-radius: var(--radius-sm);
+}
+
+.spacing-row:hover {
+  background: rgba(128, 128, 128, 0.04);
+}
+
+.spacing-label {
+  width: 24px;
+  font-size: 11px;
+  font-family: var(--font-family-mono);
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.spacing-track {
+  flex: 1;
+  height: 14px;
+  display: flex;
+  align-items: center;
+}
+
+.spacing-bar {
+  height: 100%;
+  background: var(--color-primary);
+  border-radius: 2px;
+  min-width: 4px;
+  opacity: 0.35;
+  transition: opacity var(--duration-base) var(--ease-out);
+}
+
+.spacing-row:hover .spacing-bar {
+  opacity: 0.7;
+}
+
+.spacing-px {
+  width: 32px;
+  font-size: 10.5px;
+  font-family: var(--font-family-mono);
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+/* ============================================
+   SHADOWS
+   ============================================ */
+.shadow-strip {
+  display: flex;
+  gap: var(--space-5);
+  align-items: flex-end;
+}
+
+.shadow-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.shadow-box {
+  width: 100%;
+  aspect-ratio: 1;
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-lg);
+  transition: transform var(--duration-medium) var(--ease-out);
+}
+
+.shadow-item:hover .shadow-box {
+  transform: translateY(-2px);
+}
+
+.shadow-label {
+  font-size: 10.5px;
+  font-family: var(--font-family-mono);
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+}
+
+/* ============================================
+   RADIUS
+   ============================================ */
+.radius-strip {
+  display: flex;
+  gap: var(--space-6);
+  align-items: flex-end;
+}
+
+.radius-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.radius-shape {
+  width: 44px;
+  height: 44px;
+  background: transparent;
+  border: 1.5px solid var(--color-primary);
+  opacity: 0.6;
+  transition: opacity var(--duration-fast);
+}
+
+.radius-item:hover .radius-shape {
+  opacity: 1;
+}
+
+.radius-label {
+  font-size: 10.5px;
+  font-family: var(--font-family-mono);
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+}
+
+/* ============================================
+   COMPONENT DEMOS
+   ============================================ */
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.demo-row--center {
+  align-items: center;
+}
+
+.field-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.control-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.alert-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.spinner-demo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.mono-label {
+  font-size: 10.5px;
+  font-family: var(--font-family-mono);
+  font-weight: 400;
+  color: var(--color-text-tertiary);
+}
+
+/* ============================================
+   MODAL
+   ============================================ */
+.modal-demo {
+  padding: var(--space-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 380px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+/* ============================================
+   RESPONSIVE
+   ============================================ */
+@media (max-width: 960px) {
+  .sidebar {
+    display: none;
+  }
+  .content {
+    margin-left: 0;
+    padding: var(--space-8) var(--space-6) var(--space-16);
+  }
+  .card-row,
+  .card-row--thirds {
+    grid-template-columns: 1fr;
+  }
+  .semantic-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .shadow-strip,
+  .radius-strip {
+    flex-wrap: wrap;
+  }
+  .type-colors {
+    grid-template-columns: 1fr;
+  }
+  .page-title {
+    font-size: 2rem;
+  }
+}
+</style>

--- a/src/design-system/main.ts
+++ b/src/design-system/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from "vue";
+import "../global.css";
+import App from "./App.vue";
+
+createApp(App).mount("#app");

--- a/src/icons/GitHubIcon.vue
+++ b/src/icons/GitHubIcon.vue
@@ -5,7 +5,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  size: 60,
+  size: 50,
 });
 </script>
 
@@ -38,5 +38,10 @@ svg {
   position: absolute;
   top: 0;
   right: 0;
+  opacity: 0.5;
+  transition: opacity var(--duration-fast, 0.1s) ease-out;
+}
+svg:hover {
+  opacity: 0.8;
 }
 </style>

--- a/src/lib/components/forms/Button.vue
+++ b/src/lib/components/forms/Button.vue
@@ -59,12 +59,18 @@ const style = computed(() => (props.hue !== undefined ? `--hue: ${props.hue}` : 
 .btn {
   margin: 0;
   padding: var(--space-2) var(--space-5);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
+  border-radius: var(--radius-lg);
+  box-shadow: none;
   cursor: pointer;
   font-family: var(--font-family-base);
-  font-weight: var(--font-weight-medium);
-  transition: var(--transition-colors), var(--transition-transform);
+  font-weight: 400;
+  letter-spacing: -0.005em;
+  transition:
+    background var(--duration-medium) var(--ease-out),
+    border-color var(--duration-medium) var(--ease-out),
+    box-shadow var(--duration-medium) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out),
+    filter var(--duration-fast) var(--ease-out);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -73,8 +79,10 @@ const style = computed(() => (props.hue !== undefined ? `--hue: ${props.hue}` : 
   border: var(--border-width-1) solid transparent;
 }
 .btn:focus-visible {
-  outline: 2px solid var(--color-border-focus);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--color-bg),
+    0 0 0 4px var(--color-border-focus);
 }
 .btn--primary {
   color: var(--color-primary);
@@ -82,8 +90,7 @@ const style = computed(() => (props.hue !== undefined ? `--hue: ${props.hue}` : 
   border-color: var(--color-primary);
 }
 .btn--primary:hover:not(:disabled) {
-  background: var(--color-primary-hover);
-  filter: brightness(0.95);
+  filter: brightness(0.97);
 }
 .btn--primary:active:not(:disabled) {
   transform: scale(0.98);
@@ -94,20 +101,20 @@ const style = computed(() => (props.hue !== undefined ? `--hue: ${props.hue}` : 
   border-color: var(--color-border);
 }
 .btn--secondary:hover:not(:disabled) {
-  background: var(--color-bg-elevated);
   border-color: var(--color-text-secondary);
+  background: var(--color-bg-elevated);
 }
 .btn--secondary:active:not(:disabled) {
   transform: scale(0.98);
 }
 .btn--ghost {
-  color: var(--color-text-primary);
+  color: var(--color-text-secondary);
   background: transparent;
   border-color: transparent;
-  box-shadow: none;
 }
 .btn--ghost:hover:not(:disabled) {
-  background: var(--color-bg-offset);
+  background: var(--color-bg-active);
+  color: var(--color-text);
 }
 .btn--ghost:active:not(:disabled) {
   transform: scale(0.98);
@@ -116,7 +123,6 @@ const style = computed(() => (props.hue !== undefined ? `--hue: ${props.hue}` : 
   color: var(--color-primary);
   background: transparent;
   border-color: var(--color-primary);
-  box-shadow: none;
 }
 .btn--outline:hover:not(:disabled) {
   background: var(--color-primary-bg);
@@ -130,7 +136,7 @@ const style = computed(() => (props.hue !== undefined ? `--hue: ${props.hue}` : 
   border-color: var(--color-error);
 }
 .btn--danger:hover:not(:disabled) {
-  filter: brightness(1.1);
+  filter: brightness(1.08);
 }
 .btn--danger:active:not(:disabled) {
   transform: scale(0.98);
@@ -154,10 +160,10 @@ const style = computed(() => (props.hue !== undefined ? `--hue: ${props.hue}` : 
 .btn__spinner {
   width: 1em;
   height: 1em;
-  border: 2px solid currentColor;
+  border: 1.5px solid currentColor;
   border-right-color: transparent;
   border-radius: 50%;
-  animation: spin 0.6s linear infinite;
+  animation: spin 0.7s linear infinite;
 }
 @keyframes spin {
   to {
@@ -165,7 +171,7 @@ const style = computed(() => (props.hue !== undefined ? `--hue: ${props.hue}` : 
   }
 }
 .btn__content--loading {
-  opacity: 0.7;
+  opacity: 0.6;
 }
 .btn.styled {
   color: var(--hsl);
@@ -173,7 +179,7 @@ const style = computed(() => (props.hue !== undefined ? `--hue: ${props.hue}` : 
   border-color: var(--hsl);
 }
 .btn.styled:hover:not(:disabled) {
-  filter: brightness(0.95);
+  filter: brightness(0.97);
 }
 .btn.styled:active:not(:disabled) {
   transform: scale(0.98);

--- a/src/lib/components/forms/Input.vue
+++ b/src/lib/components/forms/Input.vue
@@ -88,23 +88,25 @@ function handleInput(e: Event) {
 }
 .input {
   margin: 0;
-  padding: var(--space-2) var(--space-4);
-  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-lg);
   border: var(--border-width-1) solid var(--color-border);
   background: var(--color-bg-input);
   color: var(--color-text);
   font-family: var(--font-family-base);
-  transition: var(--transition-colors);
+  transition:
+    border-color var(--duration-medium) var(--ease-out),
+    box-shadow var(--duration-medium) var(--ease-out);
   box-sizing: border-box;
 }
 .input::placeholder {
   color: var(--color-text-tertiary);
-  opacity: 0.6;
+  opacity: 0.55;
 }
 .input:focus {
   outline: none;
   border-color: var(--color-border-focus);
-  box-shadow: var(--shadow-input-focus);
+  box-shadow: 0 0 0 3px rgba(123, 142, 230, 0.25);
 }
 .input--default:hover:not(:disabled):not(:focus) {
   border-color: var(--color-text-secondary);
@@ -118,7 +120,7 @@ function handleInput(e: Event) {
   height: var(--size-input-height-base);
 }
 .input--lg {
-  padding: var(--space-3) var(--space-5);
+  padding: var(--space-3) var(--space-4);
   font-size: var(--font-size-lg);
   height: var(--size-input-height-lg);
 }
@@ -127,18 +129,21 @@ function handleInput(e: Event) {
 }
 .input--error:focus {
   border-color: var(--color-error);
+  box-shadow: 0 0 0 3px rgba(220, 80, 80, 0.1);
 }
 .input-error {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 400;
   color: var(--color-error);
   margin-top: var(--space-1);
+  letter-spacing: 0.01em;
 }
 .input--full-width {
   width: 100%;
 }
 .input:disabled,
 .input--disabled {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: not-allowed;
   background: var(--color-bg-offset);
 }
@@ -149,6 +154,6 @@ function handleInput(e: Event) {
 }
 .input.styled:focus {
   border-color: var(--hsl);
-  box-shadow: var(--shadow-input-focus);
+  box-shadow: 0 0 0 3px rgba(123, 142, 230, 0.25);
 }
 </style>

--- a/src/lib/components/forms/Label.vue
+++ b/src/lib/components/forms/Label.vue
@@ -41,8 +41,9 @@ const classes = computed(() => ["label", `label--${props.size}`].join(" "));
 .label {
   display: block;
   color: var(--color-text-secondary);
-  font-weight: var(--font-weight-medium);
-  margin-bottom: var(--space-1);
+  font-weight: var(--font-weight-normal);
+  margin-bottom: var(--space-2);
+  letter-spacing: 0.005em;
 }
 .label--sm {
   font-size: var(--font-size-sm);
@@ -58,6 +59,7 @@ const classes = computed(() => ["label", `label--${props.size}`].join(" "));
 }
 .label-indicator--required {
   color: var(--color-error);
+  font-weight: var(--font-weight-normal);
 }
 .label-indicator--optional {
   color: var(--color-text-tertiary);

--- a/src/lib/components/forms/Select.vue
+++ b/src/lib/components/forms/Select.vue
@@ -94,20 +94,22 @@ function handleChange(e: Event) {
 }
 .select {
   margin: 0;
-  padding: var(--space-2) var(--space-4);
-  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-lg);
   border: var(--border-width-1) solid var(--color-border);
   background: var(--color-bg-input);
   color: var(--color-text);
   font-family: var(--font-family-base);
-  transition: var(--transition-colors);
+  transition:
+    border-color var(--duration-medium) var(--ease-out),
+    box-shadow var(--duration-medium) var(--ease-out);
   box-sizing: border-box;
   cursor: pointer;
 }
 .select:focus {
   outline: none;
   border-color: var(--color-border-focus);
-  box-shadow: var(--shadow-input-focus);
+  box-shadow: 0 0 0 3px rgba(123, 142, 230, 0.25);
 }
 .select--default:hover:not(:disabled):not(:focus) {
   border-color: var(--color-text-secondary);
@@ -121,7 +123,7 @@ function handleChange(e: Event) {
   height: var(--size-input-height-base);
 }
 .select--lg {
-  padding: var(--space-3) var(--space-5);
+  padding: var(--space-3) var(--space-4);
   font-size: var(--font-size-lg);
   height: var(--size-input-height-lg);
 }
@@ -130,18 +132,21 @@ function handleChange(e: Event) {
 }
 .select--error:focus {
   border-color: var(--color-error);
+  box-shadow: 0 0 0 3px rgba(220, 80, 80, 0.1);
 }
 .select-error {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 400;
   color: var(--color-error);
   margin-top: var(--space-1);
+  letter-spacing: 0.01em;
 }
 .select--full-width {
   width: 100%;
 }
 .select:disabled,
 .select--disabled {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: not-allowed;
   background: var(--color-bg-offset);
 }
@@ -152,7 +157,7 @@ function handleChange(e: Event) {
 }
 .select.styled:focus {
   border-color: var(--hsl);
-  box-shadow: var(--shadow-input-focus);
+  box-shadow: 0 0 0 3px rgba(123, 142, 230, 0.25);
 }
 option {
   background: var(--color-bg-input);

--- a/src/lib/components/forms/TextArea.vue
+++ b/src/lib/components/forms/TextArea.vue
@@ -77,26 +77,28 @@ function handleInput(e: Event) {
 }
 .textarea {
   margin: 0;
-  padding: var(--space-3) var(--space-4);
-  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-3);
+  border-radius: var(--radius-lg);
   border: var(--border-width-1) solid var(--color-border);
   background: var(--color-bg-input);
   color: var(--color-text);
   font-family: var(--font-family-base);
   font-size: var(--font-size-base);
   line-height: var(--line-height-normal);
-  transition: var(--transition-colors);
+  transition:
+    border-color var(--duration-medium) var(--ease-out),
+    box-shadow var(--duration-medium) var(--ease-out);
   box-sizing: border-box;
   min-height: 5rem;
 }
 .textarea::placeholder {
   color: var(--color-text-tertiary);
-  opacity: 0.6;
+  opacity: 0.55;
 }
 .textarea:focus {
   outline: none;
   border-color: var(--color-border-focus);
-  box-shadow: var(--shadow-input-focus);
+  box-shadow: 0 0 0 3px rgba(123, 142, 230, 0.25);
 }
 .textarea:hover:not(:disabled):not(:focus) {
   border-color: var(--color-text-secondary);
@@ -118,18 +120,21 @@ function handleInput(e: Event) {
 }
 .textarea--error:focus {
   border-color: var(--color-error);
+  box-shadow: 0 0 0 3px rgba(220, 80, 80, 0.1);
 }
 .textarea-error {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 400;
   color: var(--color-error);
   margin-top: var(--space-1);
+  letter-spacing: 0.01em;
 }
 .textarea--full-width {
   width: 100%;
 }
 .textarea:disabled,
 .textarea--disabled {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: not-allowed;
   background: var(--color-bg-offset);
 }

--- a/src/lib/components/overlay/Modal.vue
+++ b/src/lib/components/overlay/Modal.vue
@@ -68,14 +68,18 @@ watch(
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding-top: 15vh;
+  padding-top: 18vh;
   z-index: var(--z-modal-backdrop);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 
 .modal-content {
   background: var(--color-bg-elevated);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-xl);
+  border-radius: var(--radius-2xl);
+  box-shadow:
+    0 24px 48px -12px rgba(0, 0, 0, 0.18),
+    0 0 0 1px rgba(128, 128, 128, 0.08);
   z-index: var(--z-modal);
   max-height: 70vh;
   overflow: hidden;
@@ -86,14 +90,12 @@ watch(
 /* Transition animations */
 .modal-enter-active,
 .modal-leave-active {
-  transition:
-    opacity var(--duration-medium) var(--ease-out),
-    transform var(--duration-medium) var(--ease-out);
+  transition: opacity var(--duration-slow) var(--ease-out);
 }
 
 .modal-enter-active .modal-content,
 .modal-leave-active .modal-content {
-  transition: transform var(--duration-medium) var(--ease-out);
+  transition: transform var(--duration-slow) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .modal-enter-from,
@@ -103,6 +105,6 @@ watch(
 
 .modal-enter-from .modal-content,
 .modal-leave-to .modal-content {
-  transform: scale(0.95) translateY(-10px);
+  transform: scale(0.96) translateY(-8px);
 }
 </style>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -14,7 +14,7 @@ body {
   color: var(--color-text);
   background: var(--color-bg);
   transition:
-    background var(--duration-base),
+    background var(--duration-medium) var(--ease-out),
     color var(--duration-fast);
 
   margin: 0;
@@ -23,6 +23,8 @@ body {
   font-family: var(--font-family-base);
   font-size: var(--font-size-base);
   line-height: var(--line-height-normal);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 
   overflow-y: scroll;
 }
@@ -56,22 +58,26 @@ select,
 textarea {
   font-family: inherit;
   font-size: inherit;
-  padding: 0.4em 1em;
-  margin: 0 0 0.5em 0;
+  padding: 0.4em 0.75em;
+  margin: 0;
   box-sizing: border-box;
   border: var(--border-width-1) solid var(--color-border);
-  border-radius: var(--radius-sm);
-  transition: var(--transition-colors);
+  border-radius: var(--radius-lg);
+  transition:
+    border-color var(--duration-medium) var(--ease-out),
+    box-shadow var(--duration-medium) var(--ease-out),
+    background var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
 }
 
 input::placeholder {
   color: inherit;
-  opacity: 0.5;
+  opacity: 0.4;
 }
 
 input:disabled {
   color: var(--color-text-tertiary);
-  opacity: 0.6;
+  opacity: 0.5;
 }
 
 input[type="range"] {
@@ -88,16 +94,18 @@ button {
 button:disabled {
   color: var(--color-text-tertiary);
   cursor: not-allowed;
-  opacity: 0.6;
+  opacity: 0.5;
 }
 
 button:not(:disabled):active {
   background-color: var(--color-bg-active);
 }
 
-button:focus {
-  outline: var(--border-width-2) solid var(--color-border-focus);
-  outline-offset: var(--border-width-2);
+button:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--color-bg),
+    0 0 0 4px var(--color-border-focus);
 }
 
 /* ==========================================
@@ -121,16 +129,19 @@ button.underline-btn {
   color: var(--hsl);
   background: var(--hsl-bg);
   transition:
-    background var(--duration-medium),
-    color var(--duration-fast);
+    background var(--duration-medium) var(--ease-out),
+    color var(--duration-fast),
+    border-color var(--duration-medium) var(--ease-out),
+    box-shadow var(--duration-medium) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out);
 
   border: var(--border-width-1) solid var(--hsl);
-  border-radius: var(--radius-base);
+  border-radius: var(--radius-lg);
 }
 
 button.styled:hover:not(:disabled),
 select.styled:hover:not(:disabled) {
-  filter: brightness(0.95);
+  filter: brightness(0.97);
 }
 
 button.styled:active:not(:disabled),

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -31,7 +31,7 @@
   --color-bg-input: white;
   --color-text: #30354b;
   --color-text-secondary: #4b558c;
-  --color-text-tertiary: #6b7099;
+  --color-text-tertiary: #5c6085;
   --color-text-primary: #584ca4;
 
   /* Backward compatibility aliases */
@@ -55,8 +55,8 @@
   --color-info-border: hsl(210, 80%, 50%);
 
   /* Border Colors */
-  --color-border: #ccc;
-  --color-border-focus: #a5b5ff;
+  --color-border: #b8bdd4;
+  --color-border-focus: #7b8ee6;
   --color-border-error: var(--color-error);
 
   /* Link Colors */
@@ -223,14 +223,15 @@
   --color-bg-input: white;
   --color-text: #30354b;
   --color-text-secondary: #4b558c;
-  --color-text-tertiary: #6b7099;
+  --color-text-tertiary: #5c6085;
   --color-text-primary: #584ca4;
 
   --hsl-lightness: 39%;
   --hsl-bg-lightness: 95%;
   --primary-text: #584ca4;
 
-  --color-border: #ccc;
+  --color-border: #b8bdd4;
+  --color-border-focus: #7b8ee6;
   --color-shadow: rgba(0, 0, 0, 0.09);
   --color-shadow-elevated: rgba(0, 0, 0, 0.12);
 
@@ -251,14 +252,14 @@
   --color-bg-input: #151515;
   --color-text: #d3d6e3;
   --color-text-secondary: #9da6dd;
-  --color-text-tertiary: #7b84b3;
+  --color-text-tertiary: #8d95c4;
   --color-text-primary: #a89ee6;
 
   --hsl-lightness: 50%;
   --hsl-bg-lightness: 5%;
   --primary-text: #a89ee6;
 
-  --color-border: #6b6b6b;
+  --color-border: #555;
   --color-border-focus: #8a9aff;
 
   --color-shadow: rgba(0, 0, 0, 0.43);
@@ -301,7 +302,7 @@
     --color-bg-input: #151515;
     --color-text: #d3d6e3;
     --color-text-secondary: #9da6dd;
-    --color-text-tertiary: #7b84b3;
+    --color-text-tertiary: #8d95c4;
     --color-text-primary: #a89ee6;
 
     --hsl-lightness: 50%;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,4 +15,11 @@ export default defineConfig({
 		},
 	},
 	plugins: [vue()],
+	build: {
+		rollupOptions: {
+			input: {
+				main: path.resolve(__dirname, "index.html"),
+			},
+		},
+	},
 });


### PR DESCRIPTION
## Summary

- Add dev-only `/design-system` page showcasing all tokens and components (excluded from production build)
- Refine color tokens for better contrast in both light and dark themes
- Update form components with softer radius, smoother transitions, and ring-style focus states
- Restyle results rows, info panel, command palette, and header with lighter typography
- Add backdrop blur and spring animation to Modal
- Fix hover/disabled contrast issues across all components